### PR TITLE
chore: move csv mapping test to infrastructure suite

### DIFF
--- a/tests/infrastructure/pokemonCsv.test.ts
+++ b/tests/infrastructure/pokemonCsv.test.ts
@@ -1,4 +1,4 @@
-// tests/domain/pokemonCsv.test.ts
+// tests/infrastructure/pokemonCsv.test.ts
 import { describe, it, expect } from 'vitest';
 import * as S from 'effect/Schema';
 import { PokemonCsvRow, toPokemon } from '@/infrastructure/csv/pokemonCsv';


### PR DESCRIPTION
## Summary
- move `pokemonCsv` test to infrastructure folder to better reflect layer boundaries

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68a04008a5348330a72d28d135a711e9