### PR TITLE
refactor pokemon api routes to use service layer

### DIFF
--- a/src/app/api/pokemon/route.ts
+++ b/src/app/api/pokemon/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { Effect, Schema as S } from 'effect';
+import { Effect } from 'effect';
 import path from 'node:path';
-import { listFromCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
+import { list, QueryInput } from '@/application/pokemon/list';
 
 const DATA_PATH = path.resolve(
   process.cwd(),
@@ -10,56 +10,20 @@ const DATA_PATH = path.resolve(
     : 'data/pokemonCsv.csv'
 );
 
-// ❶ 定義 Schema（執行時存在的值）
-export const QuerySchema = S.Struct({
-  q: S.optional(S.String),
-  legendary: S.optional(S.String), // 寬鬆接收，後面轉布林
-  page: S.optional(S.NumberFromString),
-  pageSize: S.optional(S.NumberFromString),
-  sort: S.optional(S.String),
-});
-
-// ❷ 型別推導（編譯時存在）
-export type Query = S.Schema.Type<typeof QuerySchema>; // 驗證後型別
-export type QueryInput = S.Schema.Encoded<typeof QuerySchema>; // 驗證前型別
-
-// ❸ 把 URLSearchParams → QueryInput
+// 把 URLSearchParams → QueryInput
 function getQueryInput(req: NextRequest): QueryInput {
   const url = new URL(req.url);
-  // Object.fromEntries(entries()) 是 { [key: string]: string }
   return Object.fromEntries(url.searchParams.entries()) as QueryInput;
 }
 
-// ❹ 寬鬆轉布林
-function toBoolLike(raw?: string | null): boolean | undefined {
-  if (raw == null) return undefined;
-  const v = raw.trim().toLowerCase();
-  if (['true', '1', 'yes', 'y'].includes(v)) return true;
-  if (['false', '0', 'no', 'n'].includes(v)) return false;
-  return undefined;
-}
-
-// ❺ API route
+// API route
 export async function GET(req: NextRequest) {
-  return await Effect.runPromise(
-    Effect.match(
-      // decodeUnknown 的輸入就是 QueryInput，回傳 Effect<never, ParseError, Query>
-      Effect.flatMap(
-        S.decodeUnknown(QuerySchema)(getQueryInput(req)),
-        (q: Query) =>
-          listFromCsv(DATA_PATH, {
-            ...q,
-            legendary: toBoolLike(q.legendary),
-          })
-      ),
-      {
-        onFailure: (e) =>
-          NextResponse.json(
-            { error: { code: 'INVALID_INPUT', message: String(e) } },
-            { status: 400 }
-          ),
-        onSuccess: (data) => NextResponse.json(data),
-      }
-    )
-  );
+  const result = await Effect.runPromise(list(DATA_PATH, getQueryInput(req)));
+  if (result._tag === 'Left') {
+    return NextResponse.json(
+      { error: { code: 'INVALID_INPUT', message: result.left.message } },
+      { status: 400 }
+    );
+  }
+  return NextResponse.json(result.right);
 }

--- a/src/application/errors.ts
+++ b/src/application/errors.ts
@@ -1,0 +1,6 @@
+export type InvalidInput = { _tag: 'InvalidInput'; message: string };
+export type NotFound = { _tag: 'NotFound'; message: string };
+export type ServiceError = InvalidInput | NotFound;
+
+export const invalidInput = (message: string): InvalidInput => ({ _tag: 'InvalidInput', message });
+export const notFound = (message: string): NotFound => ({ _tag: 'NotFound', message });

--- a/src/application/pokemon/detail.ts
+++ b/src/application/pokemon/detail.ts
@@ -1,0 +1,35 @@
+import { Effect, Schema as S } from 'effect';
+import { getByIdWithSimilar, NotFound as RepoNotFound } from '@/infrastructure/repositories/PokemonRepositoryCsv';
+import { invalidInput, notFound } from '../errors';
+
+export const PathSchema = S.Struct({ id: S.NumberFromString });
+export type Path = S.Schema.Type<typeof PathSchema>;
+export type PathInput = S.Schema.Encoded<typeof PathSchema>;
+
+export const QuerySchema = S.Struct({ k: S.optional(S.NumberFromString) });
+export type Query = S.Schema.Type<typeof QuerySchema>;
+export type QueryInput = S.Schema.Encoded<typeof QuerySchema>;
+
+export interface Input {
+  path: PathInput;
+  query: QueryInput;
+}
+
+export function detail(path: string, input: Input) {
+  const eff = S.decodeUnknown(PathSchema)(input.path).pipe(
+    Effect.mapError((e) => invalidInput(String(e))),
+    Effect.flatMap((p: Path) =>
+      S.decodeUnknown(QuerySchema)(input.query).pipe(
+        Effect.mapError((e) => invalidInput(String(e))),
+        Effect.flatMap((q: Query) =>
+          getByIdWithSimilar(path, p.id, q.k ?? 5).pipe(
+            Effect.mapError((e) =>
+              e instanceof RepoNotFound ? notFound(e.message) : invalidInput(String(e))
+            )
+          )
+        )
+      )
+    )
+  );
+  return Effect.either(eff);
+}

--- a/src/application/pokemon/list.ts
+++ b/src/application/pokemon/list.ts
@@ -1,0 +1,35 @@
+import { Effect, Schema as S } from 'effect';
+import { listFromCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
+import { invalidInput } from '../errors';
+
+export const QuerySchema = S.Struct({
+  q: S.optional(S.String),
+  legendary: S.optional(S.String),
+  page: S.optional(S.NumberFromString),
+  pageSize: S.optional(S.NumberFromString),
+  sort: S.optional(S.String),
+});
+
+export type Query = S.Schema.Type<typeof QuerySchema>;
+export type QueryInput = S.Schema.Encoded<typeof QuerySchema>;
+
+function toBoolLike(raw?: string | null): boolean | undefined {
+  if (raw == null) return undefined;
+  const v = raw.trim().toLowerCase();
+  if (['true', '1', 'yes', 'y'].includes(v)) return true;
+  if (['false', '0', 'no', 'n'].includes(v)) return false;
+  return undefined;
+}
+
+export function list(path: string, input: QueryInput) {
+  const eff = S.decodeUnknown(QuerySchema)(input).pipe(
+    Effect.mapError((e) => invalidInput(String(e))),
+    Effect.flatMap((q: Query) =>
+      listFromCsv(path, {
+        ...q,
+        legendary: toBoolLike(q.legendary),
+      })
+    )
+  );
+  return Effect.either(eff);
+}


### PR DESCRIPTION
## Summary
- add application service layer with validation and unified errors
- simplify Pokemon API routes to delegate logic to services

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a04009aff083308ed3ce5977dfaa26