### PR TITLE
feat: add Pokemon repository interface

### DIFF
--- a/src/app/api/pokemon/[id]/route.ts
+++ b/src/app/api/pokemon/[id]/route.ts
@@ -3,8 +3,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Effect, Schema as S } from 'effect';
 import path from 'node:path';
 import {
-  getByIdWithSimilar,
+  PokemonRepository,
   NotFound,
+} from '@/domain/repositories/PokemonRepository';
+import {
+  PokemonRepository as PokemonRepositoryCsv,
 } from '@/infrastructure/repositories/PokemonRepositoryCsv';
 
 const DATA_PATH = path.resolve(
@@ -13,6 +16,8 @@ const DATA_PATH = path.resolve(
     ? 'data/pokemon_fixture_30.csv'
     : 'data/pokemonCsv.csv'
 );
+
+const repo: PokemonRepository = new PokemonRepositoryCsv(DATA_PATH);
 
 // Path: /api/pokemon/[id]
 export const PathSchema = S.Struct({ id: S.NumberFromString });
@@ -40,7 +45,7 @@ export async function GET(_req: NextRequest, ctx: { params: { id: string } }) {
     (p: Path) =>
       Effect.flatMap(
         S.decodeUnknown(QuerySchema)(getQueryInput(_req)),
-        (q: Query) => getByIdWithSimilar(DATA_PATH, p.id, q.k ?? 5)
+        (q: Query) => repo.getByIdWithSimilar(p.id, q.k ?? 5)
       )
   );
 

--- a/src/app/api/pokemon/route.ts
+++ b/src/app/api/pokemon/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Effect, Schema as S } from 'effect';
 import path from 'node:path';
-import { listFromCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
+import { PokemonRepository } from '@/domain/repositories/PokemonRepository';
+import {
+  PokemonRepository as PokemonRepositoryCsv,
+} from '@/infrastructure/repositories/PokemonRepositoryCsv';
 
 const DATA_PATH = path.resolve(
   process.cwd(),
@@ -9,6 +12,8 @@ const DATA_PATH = path.resolve(
     ? 'data/pokemon_fixture_30.csv'
     : 'data/pokemonCsv.csv'
 );
+
+const repo: PokemonRepository = new PokemonRepositoryCsv(DATA_PATH);
 
 // ❶ 定義 Schema（執行時存在的值）
 export const QuerySchema = S.Struct({
@@ -47,7 +52,7 @@ export async function GET(req: NextRequest) {
       Effect.flatMap(
         S.decodeUnknown(QuerySchema)(getQueryInput(req)),
         (q: Query) =>
-          listFromCsv(DATA_PATH, {
+          repo.list({
             ...q,
             legendary: toBoolLike(q.legendary),
           })

--- a/src/domain/repositories/PokemonRepository.ts
+++ b/src/domain/repositories/PokemonRepository.ts
@@ -1,0 +1,23 @@
+import { Effect } from 'effect';
+import type { Pokemon } from '@/infrastructure/csv/pokemonCsv';
+
+export type ListQuery = {
+  q?: string;
+  legendary?: boolean;
+  page?: number;
+  pageSize?: number;
+  sort?: string; // 例如: "bst:desc,name:asc"
+};
+
+export interface PokemonRepository {
+  list(query: ListQuery): Effect.Effect<{ total: number; page: number; pageSize: number; data: Pokemon[] }, Error, never>;
+  getById(id: number): Effect.Effect<Pokemon, NotFound | Error, never>;
+  getByIdWithSimilar(id: number, k?: number): Effect.Effect<{ pokemon: Pokemon; similar: Pokemon[] }, NotFound | Error, never>;
+}
+
+export class NotFound extends Error {
+  readonly _tag = 'NotFound';
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/tests/integration/repo-detail.test.ts
+++ b/tests/integration/repo-detail.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { Effect, Either } from 'effect';
 import { readPokemonCsv } from '@/infrastructure/csv/CsvService';
 import {
-  getByIdWithSimilar,
+  PokemonRepository,
   NotFound,
+} from '@/domain/repositories/PokemonRepository';
+import {
+  PokemonRepository as PokemonRepositoryCsv,
 } from '@/infrastructure/repositories/PokemonRepositoryCsv';
 
 const FIXTURE = 'data/pokemon_fixture_30.csv';
@@ -17,7 +20,8 @@ describe('整合：單筆 + 相似度', () => {
     const id = rows[0].id;
     const k = 5;
 
-    const eff = getByIdWithSimilar(FIXTURE, id, k);
+    const repo: PokemonRepository = new PokemonRepositoryCsv(FIXTURE);
+    const eff = repo.getByIdWithSimilar(id, k);
     const r = await Effect.runPromise(Effect.either(eff));
     expect(Either.isRight(r)).toBe(true);
 
@@ -33,7 +37,8 @@ describe('整合：單筆 + 相似度', () => {
   });
 
   it('找不到 id 時回 NotFound', async () => {
-    const eff = getByIdWithSimilar(FIXTURE, 9999, 0);
+    const repo: PokemonRepository = new PokemonRepositoryCsv(FIXTURE);
+    const eff = repo.getByIdWithSimilar(9999, 0);
 
     const r = await Effect.runPromise(Effect.either(eff));
     expect(Either.isLeft(r)).toBe(true);

--- a/tests/integration/repo-list.test.ts
+++ b/tests/integration/repo-list.test.ts
@@ -1,13 +1,17 @@
 // tests/integration/repo-list.test.ts
 import { describe, it, expect } from 'vitest';
 import { Effect, Either } from 'effect';
-import { listFromCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
+import { PokemonRepository } from '@/domain/repositories/PokemonRepository';
+import {
+  PokemonRepository as PokemonRepositoryCsv,
+} from '@/infrastructure/repositories/PokemonRepositoryCsv';
 
 const FIXTURE = 'data/pokemon_fixture_30.csv';
 
 describe('整合：Repository 查詢/排序/分頁', () => {
   it('legendary=true 過濾 + 多欄排序', async () => {
-    const eff = listFromCsv(FIXTURE, { legendary: true, page: 1, pageSize: 100, sort: 'bst:desc,name:asc' });
+    const repo: PokemonRepository = new PokemonRepositoryCsv(FIXTURE);
+    const eff = repo.list({ legendary: true, page: 1, pageSize: 100, sort: 'bst:desc,name:asc' });
     const r = await Effect.runPromise(Effect.either(eff));
     expect(Either.isRight(r)).toBe(true);
     if (Either.isRight(r)) {


### PR DESCRIPTION
## Summary
- add PokemonRepository interface and NotFound error
- implement CSV-based PokemonRepository
- inject repository into API routes and tests

## Testing
- `yarn test:unit`
- `yarn typecheck`
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a040013d108330bc24448d0f369f1d