### PR TITLE
refactor: move pokemon domain

### DIFF
--- a/src/domain/pokemon.ts
+++ b/src/domain/pokemon.ts
@@ -1,10 +1,48 @@
 import { TYPES, type TypeName, type Multiplier } from './types';
 
+// ---- Value Objects ----
+export type PokemonId = number;
+
+export interface PokemonStats {
+  hp: number;
+  attack: number;
+  defense: number;
+  sp_atk: number;
+  sp_def: number;
+  speed: number;
+  bst: number;
+  mean?: number;
+  sd?: number;
+}
+
+// ---- Entity ----
+export interface Pokemon extends PokemonStats {
+  id: PokemonId;
+  name: string;
+  type1: TypeName;
+  type2?: TypeName | null;
+  abilities: string[];
+  generation: number;
+  expType?: string;
+  expTo100?: number;
+  finalEvolution?: boolean;
+  catchRate?: number;
+  legendary: boolean;
+  mega?: boolean;
+  alolan?: boolean;
+  galarian?: boolean;
+  against: Record<TypeName, Multiplier>;
+  height?: number;
+  weight?: number;
+  bmi?: number;
+}
+
+// ---- Pure domain logic ----
 export function parseAbilities(raw: string | null | undefined): string[] {
   if (!raw) return [];
   const tokens = raw
     .split(/[;,]/g)
-    .map(s => s.trim())
+    .map((s) => s.trim())
     .filter(Boolean);
   const seen = new Set<string>(); // lowercase for dedupe
   const out: string[] = [];
@@ -16,6 +54,18 @@ export function parseAbilities(raw: string | null | undefined): string[] {
     }
   }
   return out;
+}
+
+export function toTypeName(raw: string): TypeName {
+  if (!TYPES.includes(raw as TypeName)) throw new Error(`Unknown type: ${raw}`);
+  return raw as TypeName;
+}
+
+export function toMultiplier(n: number | undefined): Multiplier {
+  const legal = [0, 0.25, 0.5, 1, 2, 4] as const;
+  const v = n ?? 1;
+  if (!legal.includes(v as Multiplier)) throw new Error(`Illegal multiplier ${v}`);
+  return v as Multiplier;
 }
 
 export function multiplyAgainst(

--- a/src/infrastructure/repositories/PokemonRepositoryCsv.ts
+++ b/src/infrastructure/repositories/PokemonRepositoryCsv.ts
@@ -1,7 +1,7 @@
 // src/infrastructure/repositories/PokemonRepositoryCsv.ts
 import { Effect } from 'effect';
 import { readPokemonCsv } from '@/infrastructure/csv/CsvService';
-import type { Pokemon } from '@/infrastructure/csv/pokemonCsv';
+import type { Pokemon } from '@/domain/pokemon';
 
 export type ListQuery = {
   q?: string;


### PR DESCRIPTION
## Summary
- define Pokemon domain entities and value objects
- centralize parsing helpers in domain
- adapt CSV infrastructure to map rows to domain types

## Testing
- `yarn lint`
- `yarn typecheck`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68a03ffc91388330954c45f9cd45a93b