### PR TITLE
refactor: introduce Pokemon repository interface

### DIFF
--- a/src/app/api/pokemon/[id]/route.ts
+++ b/src/app/api/pokemon/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   PathInput,
   QueryInput,
 } from '@/application/pokemon/detail';
+import { PokemonRepositoryCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
 
 const DATA_PATH = path.resolve(
   process.cwd(),
@@ -25,8 +26,9 @@ function getQueryInput(req: NextRequest): QueryInput {
 }
 
 export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
+  const repo = new PokemonRepositoryCsv(DATA_PATH);
   const result = await Effect.runPromise(
-    detail(DATA_PATH, { path: getPathInput(ctx.params), query: getQueryInput(req) })
+    detail(repo, { path: getPathInput(ctx.params), query: getQueryInput(req) })
   );
   if (result._tag === 'Left') {
     const status = result.left._tag === 'NotFound' ? 404 : 400;

--- a/src/app/api/pokemon/route.ts
+++ b/src/app/api/pokemon/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Effect } from 'effect';
 import path from 'node:path';
 import { list, QueryInput } from '@/application/pokemon/list';
+import { PokemonRepositoryCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
 
 const DATA_PATH = path.resolve(
   process.cwd(),
@@ -18,7 +19,8 @@ function getQueryInput(req: NextRequest): QueryInput {
 
 // API route
 export async function GET(req: NextRequest) {
-  const result = await Effect.runPromise(list(DATA_PATH, getQueryInput(req)));
+  const repo = new PokemonRepositoryCsv(DATA_PATH);
+  const result = await Effect.runPromise(list(repo, getQueryInput(req)));
   if (result._tag === 'Left') {
     return NextResponse.json(
       { error: { code: 'INVALID_INPUT', message: result.left.message } },

--- a/src/application/pokemon/detail.ts
+++ b/src/application/pokemon/detail.ts
@@ -1,5 +1,8 @@
 import { Effect, Schema as S } from 'effect';
-import { getByIdWithSimilar, NotFound as RepoNotFound } from '@/infrastructure/repositories/PokemonRepositoryCsv';
+import {
+  type PokemonRepository,
+  NotFound as RepoNotFound,
+} from '@/application/repositories/PokemonRepository';
 import { invalidInput, notFound } from '../errors';
 
 export const PathSchema = S.Struct({ id: S.NumberFromString });
@@ -15,14 +18,14 @@ export interface Input {
   query: QueryInput;
 }
 
-export function detail(path: string, input: Input) {
+export function detail(repo: PokemonRepository, input: Input) {
   const eff = S.decodeUnknown(PathSchema)(input.path).pipe(
     Effect.mapError((e) => invalidInput(String(e))),
     Effect.flatMap((p: Path) =>
       S.decodeUnknown(QuerySchema)(input.query).pipe(
         Effect.mapError((e) => invalidInput(String(e))),
         Effect.flatMap((q: Query) =>
-          getByIdWithSimilar(path, p.id, q.k ?? 5).pipe(
+          repo.getByIdWithSimilar(p.id, q.k ?? 5).pipe(
             Effect.mapError((e) =>
               e instanceof RepoNotFound ? notFound(e.message) : invalidInput(String(e))
             )

--- a/src/application/pokemon/list.ts
+++ b/src/application/pokemon/list.ts
@@ -1,5 +1,5 @@
 import { Effect, Schema as S } from 'effect';
-import { listFromCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
+import type { PokemonRepository } from '@/application/repositories/PokemonRepository';
 import { invalidInput } from '../errors';
 
 export const QuerySchema = S.Struct({
@@ -21,11 +21,11 @@ function toBoolLike(raw?: string | null): boolean | undefined {
   return undefined;
 }
 
-export function list(path: string, input: QueryInput) {
+export function list(repo: PokemonRepository, input: QueryInput) {
   const eff = S.decodeUnknown(QuerySchema)(input).pipe(
     Effect.mapError((e) => invalidInput(String(e))),
     Effect.flatMap((q: Query) =>
-      listFromCsv(path, {
+      repo.list({
         ...q,
         legendary: toBoolLike(q.legendary),
       })

--- a/src/application/repositories/PokemonRepository.ts
+++ b/src/application/repositories/PokemonRepository.ts
@@ -1,0 +1,31 @@
+import { Effect } from 'effect';
+import type { Pokemon } from '@/domain/pokemon';
+
+export type ListQuery = {
+  q?: string;
+  legendary?: boolean;
+  page?: number;
+  pageSize?: number;
+  sort?: string;
+};
+
+export class NotFound extends Error {
+  readonly _tag = 'NotFound';
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export interface PokemonRepository {
+  list(query: ListQuery): Effect.Effect<{
+    total: number;
+    page: number;
+    pageSize: number;
+    data: Pokemon[];
+  }, Error>;
+  getById(id: number): Effect.Effect<Pokemon, Error>;
+  getByIdWithSimilar(
+    id: number,
+    k: number
+  ): Effect.Effect<{ pokemon: Pokemon; similar: Pokemon[] }, Error>;
+}

--- a/src/infrastructure/repositories/PokemonRepositoryCsv.ts
+++ b/src/infrastructure/repositories/PokemonRepositoryCsv.ts
@@ -3,21 +3,11 @@ import { Effect } from 'effect';
 import { readPokemonCsv } from '@/infrastructure/csv/CsvService';
 import type { Pokemon } from '@/domain/pokemon';
 import { toPokemon } from '@/infrastructure/csv/pokemonCsv';
+import type { PokemonRepository, ListQuery } from '@/application/repositories/PokemonRepository';
+import { NotFound } from '@/application/repositories/PokemonRepository';
 
-export type ListQuery = {
-  q?: string;
-  legendary?: boolean;
-  page?: number;
-  pageSize?: number;
-  sort?: string; // 例："bst:desc,name:asc"
-};
-
-export class NotFound extends Error {
-  readonly _tag = 'NotFound';
-  constructor(message: string) {
-    super(message);
-  }
-}
+export { NotFound } from '@/application/repositories/PokemonRepository';
+export type { ListQuery } from '@/application/repositories/PokemonRepository';
 
 /** 允許排序的欄位（白名單） */
 const ALLOWED_SORT_KEYS = new Set<keyof Pokemon>([
@@ -74,11 +64,11 @@ function getValue<K extends keyof Pokemon>(p: Pokemon, key: K): Pokemon[K] {
 
 /** 將不同型別正規化成可排序的 number 或 string（避免使用 any） */
 function normalizeForCompare(v: unknown): number | string {
-  if (v == null) return ''; // null/undefined 排到最前
+  if (v == null) return '';
   const t = typeof v;
   if (t === 'number') return v as number;
   if (t === 'boolean') return (v as boolean) ? 1 : 0;
-  return String(v); // string / enum / 其他
+  return String(v);
 }
 
 function compareByPairs(a: Pokemon, b: Pokemon, pairs: SortPair[]): number {
@@ -89,54 +79,6 @@ function compareByPairs(a: Pokemon, b: Pokemon, pairs: SortPair[]): number {
     if (av > bv) return dir === 'asc' ? 1 : -1;
   }
   return 0;
-}
-
-export function listFromCsv(path: string, query: ListQuery) {
-  return readPokemonCsv(path).pipe(
-    Effect.map((rows) => rows.map(toPokemon)),
-    Effect.map((rows) => {
-      let xs = rows.slice();
-
-      // 名稱搜尋（大小寫不敏感）
-      if (query.q) {
-        const q = query.q.toLowerCase();
-        xs = xs.filter((p) => p.name.toLowerCase().includes(q));
-      }
-      // 傳說過濾
-      if (typeof query.legendary === 'boolean') {
-        xs = xs.filter((p) => {
-          return p.legendary === query.legendary;
-        });
-      }
-
-      // 多欄排序（依白名單）
-      const sortPairs = parseSortParam(query.sort);
-      if (sortPairs.length > 0) {
-        xs.sort((a, b) => compareByPairs(a, b, sortPairs));
-      }
-
-      // 分頁
-      const page = Math.max(1, query.page ?? 1);
-      const pageSize = Math.min(200, Math.max(1, query.pageSize ?? 50));
-      const start = (page - 1) * pageSize;
-      const data = xs.slice(start, start + pageSize);
-
-      return { total: xs.length, page, pageSize, data };
-    })
-  );
-}
-
-/** 取單筆 */
-export function getById(path: string, id: number) {
-  return readPokemonCsv(path).pipe(
-    Effect.map((rows) => rows.map(toPokemon)),
-    Effect.map((rows) => rows.find((p) => p.id === id)),
-    Effect.flatMap((p) =>
-      p
-        ? Effect.succeed(p)
-        : Effect.fail(new NotFound(`Pokemon ${id} not found`))
-    )
-  );
 }
 
 /** 相似度計算（六圍的歐氏距離） */
@@ -156,23 +98,70 @@ function distance(a: Pokemon, b: Pokemon): number {
   return Math.sqrt(sum);
 }
 
-/** 單筆 + 相似度 Top K（排除自己） */
-export function getByIdWithSimilar(path: string, id: number, k = 5) {
-  const kk = Math.max(0, Math.min(50, Math.floor(k)));
-  return readPokemonCsv(path).pipe(
-    Effect.map((rows) => rows.map(toPokemon)),
-    Effect.flatMap((rows) => {
-      const self = rows.find((p) => p.id === id);
-      if (!self) return Effect.fail(new NotFound(`Pokemon ${id} not found`));
+export class PokemonRepositoryCsv implements PokemonRepository {
+  constructor(private readonly path: string) {}
 
-      const sim = rows
-        .filter((p) => p.id !== id)
-        .map((p) => ({ p, dist: distance(self, p) }))
-        .sort((a, b) => a.dist - b.dist)
-        .slice(0, kk)
-        .map((x) => x.p);
+  list(
+    query: ListQuery
+  ): Effect.Effect<{ total: number; page: number; pageSize: number; data: Pokemon[] }, Error> {
+    return readPokemonCsv(this.path).pipe(
+      Effect.map((rows) => rows.map(toPokemon)),
+      Effect.map((rows) => {
+        let xs = rows.slice();
 
-      return Effect.succeed({ pokemon: self, similar: sim });
-    })
-  );
+        if (query.q) {
+          const q = query.q.toLowerCase();
+          xs = xs.filter((p) => p.name.toLowerCase().includes(q));
+        }
+        if (typeof query.legendary === 'boolean') {
+          xs = xs.filter((p) => p.legendary === query.legendary);
+        }
+
+        const sortPairs = parseSortParam(query.sort);
+        if (sortPairs.length > 0) {
+          xs.sort((a, b) => compareByPairs(a, b, sortPairs));
+        }
+
+        const page = Math.max(1, query.page ?? 1);
+        const pageSize = Math.min(200, Math.max(1, query.pageSize ?? 50));
+        const start = (page - 1) * pageSize;
+        const data = xs.slice(start, start + pageSize);
+
+        return { total: xs.length, page, pageSize, data };
+      })
+    );
+  }
+
+  getById(id: number): Effect.Effect<Pokemon, Error> {
+    return readPokemonCsv(this.path).pipe(
+      Effect.map((rows) => rows.map(toPokemon)),
+      Effect.map((rows) => rows.find((p) => p.id === id)),
+      Effect.flatMap((p) =>
+        p ? Effect.succeed(p) : Effect.fail(new NotFound(`Pokemon ${id} not found`))
+      )
+    );
+  }
+
+  getByIdWithSimilar(
+    id: number,
+    k = 5
+  ): Effect.Effect<{ pokemon: Pokemon; similar: Pokemon[] }, Error> {
+    const kk = Math.max(0, Math.min(50, Math.floor(k)));
+    return readPokemonCsv(this.path).pipe(
+      Effect.map((rows) => rows.map(toPokemon)),
+      Effect.flatMap((rows) => {
+        const self = rows.find((p) => p.id === id);
+        if (!self) return Effect.fail(new NotFound(`Pokemon ${id} not found`));
+
+        const sim = rows
+          .filter((p) => p.id !== id)
+          .map((p) => ({ p, dist: distance(self, p) }))
+          .sort((a, b) => a.dist - b.dist)
+          .slice(0, kk)
+          .map((x) => x.p);
+
+        return Effect.succeed({ pokemon: self, similar: sim });
+      })
+    );
+  }
 }

--- a/tests/integration/repo-detail.test.ts
+++ b/tests/integration/repo-detail.test.ts
@@ -1,10 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { Effect, Either } from 'effect';
 import { readPokemonCsv } from '@/infrastructure/csv/CsvService';
-import {
-  getByIdWithSimilar,
-  NotFound,
-} from '@/infrastructure/repositories/PokemonRepositoryCsv';
+import { PokemonRepositoryCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
+import { NotFound } from '@/application/repositories/PokemonRepository';
 
 const FIXTURE = 'data/pokemon_fixture_30.csv';
 
@@ -17,7 +15,8 @@ describe('整合：單筆 + 相似度', () => {
     const id = rows[0].Number;
     const k = 5;
 
-    const eff = getByIdWithSimilar(FIXTURE, id, k);
+    const repo = new PokemonRepositoryCsv(FIXTURE);
+    const eff = repo.getByIdWithSimilar(id, k);
     const r = await Effect.runPromise(Effect.either(eff));
     expect(Either.isRight(r)).toBe(true);
 
@@ -33,7 +32,8 @@ describe('整合：單筆 + 相似度', () => {
   });
 
   it('找不到 id 時回 NotFound', async () => {
-    const eff = getByIdWithSimilar(FIXTURE, 9999, 0);
+    const repo = new PokemonRepositoryCsv(FIXTURE);
+    const eff = repo.getByIdWithSimilar(9999, 0);
 
     const r = await Effect.runPromise(Effect.either(eff));
     expect(Either.isLeft(r)).toBe(true);

--- a/tests/integration/repo-list.test.ts
+++ b/tests/integration/repo-list.test.ts
@@ -1,13 +1,14 @@
 // tests/integration/repo-list.test.ts
 import { describe, it, expect } from 'vitest';
 import { Effect, Either } from 'effect';
-import { listFromCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
+import { PokemonRepositoryCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
 
 const FIXTURE = 'data/pokemon_fixture_30.csv';
 
 describe('整合：Repository 查詢/排序/分頁', () => {
   it('legendary=true 過濾 + 多欄排序', async () => {
-    const eff = listFromCsv(FIXTURE, { legendary: true, page: 1, pageSize: 100, sort: 'bst:desc,name:asc' });
+    const repo = new PokemonRepositoryCsv(FIXTURE);
+    const eff = repo.list({ legendary: true, page: 1, pageSize: 100, sort: 'bst:desc,name:asc' });
     const r = await Effect.runPromise(Effect.either(eff));
     expect(Either.isRight(r)).toBe(true);
     if (Either.isRight(r)) {


### PR DESCRIPTION
## Summary
- define `PokemonRepository` abstraction with list/get/getByIdWithSimilar methods and `NotFound` error
- implement CSV-based `PokemonRepositoryCsv` and rework app logic to accept the interface
- inject repository implementation in API routes and update tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68a04844b8a88330a6ee65a1e8be5a3c