### PR TITLE
Refactor repository interface and move list logic to application layer

### DIFF
--- a/src/application/pokemon/list.ts
+++ b/src/application/pokemon/list.ts
@@ -1,5 +1,6 @@
 import { Effect, Schema as S } from 'effect';
 import type { PokemonRepository } from '@/application/repositories/PokemonRepository';
+import type { Pokemon } from '@/domain/pokemon';
 import { invalidInput } from '../errors';
 
 export const QuerySchema = S.Struct({
@@ -21,14 +22,108 @@ function toBoolLike(raw?: string | null): boolean | undefined {
   return undefined;
 }
 
+/** 允許排序的欄位（白名單） */
+const ALLOWED_SORT_KEYS = new Set<keyof Pokemon>([
+  'id',
+  'name',
+  'type1',
+  'type2',
+  'hp',
+  'attack',
+  'defense',
+  'sp_atk',
+  'sp_def',
+  'speed',
+  'bst',
+  'mean',
+  'sd',
+  'generation',
+  'expType',
+  'expTo100',
+  'finalEvolution',
+  'catchRate',
+  'legendary',
+  'mega',
+  'alolan',
+  'galarian',
+  'height',
+  'weight',
+  'bmi',
+] as Array<keyof Pokemon>);
+
+type SortDir = 'asc' | 'desc';
+type SortPair = readonly [keyof Pokemon, SortDir];
+
+function parseSortParam(sort?: string): SortPair[] {
+  if (!sort) return [];
+  const parts = sort
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const pairs: SortPair[] = [];
+  for (const part of parts) {
+    const [fieldRaw, dirRaw] = part.split(':');
+    const key = fieldRaw as keyof Pokemon;
+    if (!ALLOWED_SORT_KEYS.has(key)) continue;
+    const dir: SortDir = dirRaw?.toLowerCase() === 'desc' ? 'desc' : 'asc';
+    pairs.push([key, dir]);
+  }
+  return pairs;
+}
+
+function getValue<K extends keyof Pokemon>(p: Pokemon, key: K): Pokemon[K] {
+  return p[key];
+}
+
+/** 將不同型別正規化成可排序的 number 或 string（避免使用 any） */
+function normalizeForCompare(v: unknown): number | string {
+  if (v == null) return '';
+  const t = typeof v;
+  if (t === 'number') return v as number;
+  if (t === 'boolean') return (v as boolean) ? 1 : 0;
+  return String(v);
+}
+
+function compareByPairs(a: Pokemon, b: Pokemon, pairs: SortPair[]): number {
+  for (const [key, dir] of pairs) {
+    const av = normalizeForCompare(getValue(a, key));
+    const bv = normalizeForCompare(getValue(b, key));
+    if (av < bv) return dir === 'asc' ? -1 : 1;
+    if (av > bv) return dir === 'asc' ? 1 : -1;
+  }
+  return 0;
+}
+
 export function list(repo: PokemonRepository, input: QueryInput) {
   const eff = S.decodeUnknown(QuerySchema)(input).pipe(
     Effect.mapError((e) => invalidInput(String(e))),
     Effect.flatMap((q: Query) =>
-      repo.list({
-        ...q,
-        legendary: toBoolLike(q.legendary),
-      })
+      repo.getAll().pipe(
+        Effect.map((rows) => {
+          let xs = rows.slice();
+
+          if (q.q) {
+            const qq = q.q.toLowerCase();
+            xs = xs.filter((p) => p.name.toLowerCase().includes(qq));
+          }
+          const legendary = toBoolLike(q.legendary);
+          if (typeof legendary === 'boolean') {
+            xs = xs.filter((p) => p.legendary === legendary);
+          }
+
+          const sortPairs = parseSortParam(q.sort);
+          if (sortPairs.length > 0) {
+            xs.sort((a, b) => compareByPairs(a, b, sortPairs));
+          }
+
+          const page = Math.max(1, q.page ?? 1);
+          const pageSize = Math.min(200, Math.max(1, q.pageSize ?? 50));
+          const start = (page - 1) * pageSize;
+          const data = xs.slice(start, start + pageSize);
+
+          return { total: xs.length, page, pageSize, data };
+        })
+      )
     )
   );
   return Effect.either(eff);

--- a/src/application/repositories/PokemonRepository.ts
+++ b/src/application/repositories/PokemonRepository.ts
@@ -1,14 +1,6 @@
 import { Effect } from 'effect';
 import type { Pokemon } from '@/domain/pokemon';
 
-export type ListQuery = {
-  q?: string;
-  legendary?: boolean;
-  page?: number;
-  pageSize?: number;
-  sort?: string;
-};
-
 export class NotFound extends Error {
   readonly _tag = 'NotFound';
   constructor(message: string) {
@@ -17,12 +9,7 @@ export class NotFound extends Error {
 }
 
 export interface PokemonRepository {
-  list(query: ListQuery): Effect.Effect<{
-    total: number;
-    page: number;
-    pageSize: number;
-    data: Pokemon[];
-  }, Error>;
+  getAll(): Effect.Effect<ReadonlyArray<Pokemon>, Error>;
   getById(id: number): Effect.Effect<Pokemon, Error>;
   getByIdWithSimilar(
     id: number,

--- a/src/infrastructure/repositories/PokemonRepositoryCsv.ts
+++ b/src/infrastructure/repositories/PokemonRepositoryCsv.ts
@@ -3,90 +3,14 @@ import { Effect } from 'effect';
 import { readPokemonCsv } from '@/infrastructure/csv/CsvService';
 import type { Pokemon } from '@/domain/pokemon';
 import { toPokemon } from '@/infrastructure/csv/pokemonCsv';
-import type { PokemonRepository, ListQuery } from '@/application/repositories/PokemonRepository';
+import type { PokemonRepository } from '@/application/repositories/PokemonRepository';
 import { NotFound } from '@/application/repositories/PokemonRepository';
 
 export { NotFound } from '@/application/repositories/PokemonRepository';
-export type { ListQuery } from '@/application/repositories/PokemonRepository';
-
-/** 允許排序的欄位（白名單） */
-const ALLOWED_SORT_KEYS = new Set<keyof Pokemon>([
-  'id',
-  'name',
-  'type1',
-  'type2',
-  'hp',
-  'attack',
-  'defense',
-  'sp_atk',
-  'sp_def',
-  'speed',
-  'bst',
-  'mean',
-  'sd',
-  'generation',
-  'expType',
-  'expTo100',
-  'finalEvolution',
-  'catchRate',
-  'legendary',
-  'mega',
-  'alolan',
-  'galarian',
-  'height',
-  'weight',
-  'bmi',
-] as Array<keyof Pokemon>);
-
-type SortDir = 'asc' | 'desc';
-type SortPair = readonly [keyof Pokemon, SortDir];
-
-function parseSortParam(sort?: string): SortPair[] {
-  if (!sort) return [];
-  const parts = sort
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
-  const pairs: SortPair[] = [];
-  for (const part of parts) {
-    const [fieldRaw, dirRaw] = part.split(':');
-    const key = fieldRaw as keyof Pokemon;
-    if (!ALLOWED_SORT_KEYS.has(key)) continue;
-    const dir: SortDir = dirRaw?.toLowerCase() === 'desc' ? 'desc' : 'asc';
-    pairs.push([key, dir]);
-  }
-  return pairs;
-}
-
-function getValue<K extends keyof Pokemon>(p: Pokemon, key: K): Pokemon[K] {
-  return p[key];
-}
-
-/** 將不同型別正規化成可排序的 number 或 string（避免使用 any） */
-function normalizeForCompare(v: unknown): number | string {
-  if (v == null) return '';
-  const t = typeof v;
-  if (t === 'number') return v as number;
-  if (t === 'boolean') return (v as boolean) ? 1 : 0;
-  return String(v);
-}
-
-function compareByPairs(a: Pokemon, b: Pokemon, pairs: SortPair[]): number {
-  for (const [key, dir] of pairs) {
-    const av = normalizeForCompare(getValue(a, key));
-    const bv = normalizeForCompare(getValue(b, key));
-    if (av < bv) return dir === 'asc' ? -1 : 1;
-    if (av > bv) return dir === 'asc' ? 1 : -1;
-  }
-  return 0;
-}
 
 /** 相似度計算（六圍的歐氏距離） */
 const METRICS: ReadonlyArray<
-  keyof Pick<
-    Pokemon,
-    'hp' | 'attack' | 'defense' | 'sp_atk' | 'sp_def' | 'speed'
-  >
+  keyof Pick<Pokemon, 'hp' | 'attack' | 'defense' | 'sp_atk' | 'sp_def' | 'speed'>
 > = ['hp', 'attack', 'defense', 'sp_atk', 'sp_def', 'speed'] as const;
 
 function distance(a: Pokemon, b: Pokemon): number {
@@ -101,34 +25,9 @@ function distance(a: Pokemon, b: Pokemon): number {
 export class PokemonRepositoryCsv implements PokemonRepository {
   constructor(private readonly path: string) {}
 
-  list(
-    query: ListQuery
-  ): Effect.Effect<{ total: number; page: number; pageSize: number; data: Pokemon[] }, Error> {
+  getAll(): Effect.Effect<ReadonlyArray<Pokemon>, Error> {
     return readPokemonCsv(this.path).pipe(
-      Effect.map((rows) => rows.map(toPokemon)),
-      Effect.map((rows) => {
-        let xs = rows.slice();
-
-        if (query.q) {
-          const q = query.q.toLowerCase();
-          xs = xs.filter((p) => p.name.toLowerCase().includes(q));
-        }
-        if (typeof query.legendary === 'boolean') {
-          xs = xs.filter((p) => p.legendary === query.legendary);
-        }
-
-        const sortPairs = parseSortParam(query.sort);
-        if (sortPairs.length > 0) {
-          xs.sort((a, b) => compareByPairs(a, b, sortPairs));
-        }
-
-        const page = Math.max(1, query.page ?? 1);
-        const pageSize = Math.min(200, Math.max(1, query.pageSize ?? 50));
-        const start = (page - 1) * pageSize;
-        const data = xs.slice(start, start + pageSize);
-
-        return { total: xs.length, page, pageSize, data };
-      })
+      Effect.map((rows) => rows.map(toPokemon))
     );
   }
 

--- a/tests/integration/repo-list.test.ts
+++ b/tests/integration/repo-list.test.ts
@@ -2,19 +2,28 @@
 import { describe, it, expect } from 'vitest';
 import { Effect, Either } from 'effect';
 import { PokemonRepositoryCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
+import { list } from '@/application/pokemon/list';
 
 const FIXTURE = 'data/pokemon_fixture_30.csv';
 
-describe('整合：Repository 查詢/排序/分頁', () => {
+describe('整合：Application 查詢/排序/分頁', () => {
   it('legendary=true 過濾 + 多欄排序', async () => {
     const repo = new PokemonRepositoryCsv(FIXTURE);
-    const eff = repo.list({ legendary: true, page: 1, pageSize: 100, sort: 'bst:desc,name:asc' });
-    const r = await Effect.runPromise(Effect.either(eff));
+    const eff = list(repo, {
+      legendary: 'true',
+      page: '1',
+      pageSize: '100',
+      sort: 'bst:desc,name:asc',
+    });
+    const r = await Effect.runPromise(eff);
     expect(Either.isRight(r)).toBe(true);
     if (Either.isRight(r)) {
       const out = r.right;
+      expect(out.page).toBe(1);
+      expect(out.pageSize).toBe(100);
+      expect(out.total).toBeGreaterThan(0);
       expect(out.data.length).toBeGreaterThan(0);
-      expect(out.data.every(p => p.legendary)).toBe(true);
+      expect(out.data.every((p) => p.legendary)).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## Summary
- simplify `PokemonRepository` to expose basic `getAll` and id-based methods
- implement search, sort and pagination in `application/pokemon/list`
- update CSV repository and tests for application-level listing

## Testing
- `yarn test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68a04fa2672c833095baa3ae4e0b7b18