### PR TITLE
refactor: split CSV parsing

### DIFF
--- a/src/infrastructure/csv/CsvService.ts
+++ b/src/infrastructure/csv/CsvService.ts
@@ -2,23 +2,17 @@
 import { Effect } from 'effect';
 import fs from 'node:fs/promises';
 import { parse } from 'csv-parse/sync';
-import * as S from 'effect/Schema';
-import { PokemonCsvRow } from './pokemonCsv';
 
 export class DataLoadError extends Error {}
 
-export const readPokemonCsv = (path: string) =>
-  // 1) 讀檔
+export const readCsv = (
+  path: string
+): Effect.Effect<unknown[], DataLoadError> =>
   Effect.tryPromise({
     try: () => fs.readFile(path, 'utf8'),
     catch: (e) => new DataLoadError(`Failed to read CSV: ${JSON.stringify(e)}`),
   }).pipe(
-    Effect.map((raw) => parse(raw, { columns: true, skip_empty_lines: true })),
-    Effect.flatMap((rows) =>
-      Effect.forEach(rows, (r) =>
-        S.decodeUnknown(PokemonCsvRow)(r).pipe(
-          Effect.mapError((e) => new DataLoadError(String(e)))
-        )
-      )
+    Effect.map((raw) =>
+      parse(raw, { columns: true, skip_empty_lines: true }) as unknown[]
     )
   );

--- a/src/infrastructure/csv/pokemonCsv.ts
+++ b/src/infrastructure/csv/pokemonCsv.ts
@@ -1,5 +1,7 @@
 // src/infrastructure/csv/pokemonCsv.ts
+import { Effect } from 'effect';
 import * as S from 'effect/Schema';
+import { DataLoadError } from './CsvService';
 import {
   parseAbilities,
   toTypeName,
@@ -64,6 +66,15 @@ export const PokemonCsvRow = S.Struct({
   BMI: S.optional(NumStr),
 });
 export type PokemonCsvRow = S.Schema.Type<typeof PokemonCsvRow>;
+
+export const parsePokemonCsv = (
+  rows: unknown[]
+): Effect.Effect<PokemonCsvRow[], DataLoadError> =>
+  Effect.forEach(rows, (r) =>
+    S.decodeUnknown(PokemonCsvRow)(r).pipe(
+      Effect.mapError((e) => new DataLoadError(String(e)))
+    )
+  );
 
 // —— 小工具：布林轉換 ——
 

--- a/src/infrastructure/repositories/PokemonRepositoryCsv.ts
+++ b/src/infrastructure/repositories/PokemonRepositoryCsv.ts
@@ -1,8 +1,8 @@
 // src/infrastructure/repositories/PokemonRepositoryCsv.ts
 import { Effect } from 'effect';
-import { readPokemonCsv } from '@/infrastructure/csv/CsvService';
+import { readCsv } from '@/infrastructure/csv/CsvService';
 import type { Pokemon } from '@/domain/pokemon';
-import { toPokemon } from '@/infrastructure/csv/pokemonCsv';
+import { parsePokemonCsv, toPokemon } from '@/infrastructure/csv/pokemonCsv';
 import type { PokemonRepository } from '@/application/repositories/PokemonRepository';
 import { NotFound } from '@/application/repositories/PokemonRepository';
 
@@ -26,13 +26,15 @@ export class PokemonRepositoryCsv implements PokemonRepository {
   constructor(private readonly path: string) {}
 
   getAll(): Effect.Effect<ReadonlyArray<Pokemon>, Error> {
-    return readPokemonCsv(this.path).pipe(
+    return readCsv(this.path).pipe(
+      Effect.flatMap(parsePokemonCsv),
       Effect.map((rows) => rows.map(toPokemon))
     );
   }
 
   getById(id: number): Effect.Effect<Pokemon, Error> {
-    return readPokemonCsv(this.path).pipe(
+    return readCsv(this.path).pipe(
+      Effect.flatMap(parsePokemonCsv),
       Effect.map((rows) => rows.map(toPokemon)),
       Effect.map((rows) => rows.find((p) => p.id === id)),
       Effect.flatMap((p) =>
@@ -46,7 +48,8 @@ export class PokemonRepositoryCsv implements PokemonRepository {
     k = 5
   ): Effect.Effect<{ pokemon: Pokemon; similar: Pokemon[] }, Error> {
     const kk = Math.max(0, Math.min(50, Math.floor(k)));
-    return readPokemonCsv(this.path).pipe(
+    return readCsv(this.path).pipe(
+      Effect.flatMap(parsePokemonCsv),
       Effect.map((rows) => rows.map(toPokemon)),
       Effect.flatMap((rows) => {
         const self = rows.find((p) => p.id === id);

--- a/tests/integration/csv-read.test.ts
+++ b/tests/integration/csv-read.test.ts
@@ -1,13 +1,15 @@
 // tests/integration/csv-read.test.ts
 import { describe, it, expect } from 'vitest';
 import { Effect, Either } from 'effect';
-import { readPokemonCsv } from '@/infrastructure/csv/CsvService';
+import { readCsv } from '@/infrastructure/csv/CsvService';
+import { parsePokemonCsv } from '@/infrastructure/csv/pokemonCsv';
 
 const FIXTURE = 'data/pokemon_fixture_30.csv';
 
 describe('整合：CSV 解析', () => {
   it('能讀取 30 筆並解析欄位', async () => {
-    const r = await Effect.runPromise(Effect.either(readPokemonCsv(FIXTURE)));
+    const eff = readCsv(FIXTURE).pipe(Effect.flatMap(parsePokemonCsv));
+    const r = await Effect.runPromise(Effect.either(eff));
     expect(Either.isRight(r)).toBe(true);
     if (Either.isRight(r)) {
       const rows = r.right;

--- a/tests/integration/repo-detail.test.ts
+++ b/tests/integration/repo-detail.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Effect, Either } from 'effect';
-import { readPokemonCsv } from '@/infrastructure/csv/CsvService';
+import { readCsv } from '@/infrastructure/csv/CsvService';
+import { parsePokemonCsv } from '@/infrastructure/csv/pokemonCsv';
 import { PokemonRepositoryCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
 import { NotFound } from '@/application/repositories/PokemonRepository';
 
@@ -9,7 +10,9 @@ const FIXTURE = 'data/pokemon_fixture_30.csv';
 describe('整合：單筆 + 相似度', () => {
   it('能取第一筆資料的詳細與相似度 top K（不包含自己）', async () => {
     // 先讀取 CSV 拿到一個存在的 id
-    const rows = await Effect.runPromise(readPokemonCsv(FIXTURE));
+    const rows = await Effect.runPromise(
+      readCsv(FIXTURE).pipe(Effect.flatMap(parsePokemonCsv))
+    );
     expect(rows.length).toBeGreaterThan(0);
 
     const id = rows[0].Number;


### PR DESCRIPTION
## Summary
- add generic `readCsv` helper
- validate Pokémon rows via new `parsePokemonCsv`
- repository composes `readCsv` and `parsePokemonCsv`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68a05625d6bc83309482a861f28b6383