### PR TITLE
cache csv data in pokemon repository

### DIFF
--- a/tests/infrastructure/PokemonRepositoryCsv.test.ts
+++ b/tests/infrastructure/PokemonRepositoryCsv.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Effect } from 'effect';
+import fs from 'node:fs/promises';
+import { PokemonRepositoryCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
+
+const FIXTURE = 'data/pokemon_fixture_30.csv';
+
+describe('PokemonRepositoryCsv caching', () => {
+  it('reads csv only once for multiple operations', async () => {
+    const spy = vi.spyOn(fs, 'readFile');
+
+    const repo = new PokemonRepositoryCsv(FIXTURE);
+    const all = await Effect.runPromise(repo.getAll());
+    const id = all[0].id;
+
+    await Effect.runPromise(repo.getById(id));
+    await Effect.runPromise(repo.getByIdWithSimilar(id, 2));
+    await Effect.runPromise(repo.getAll());
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- cache parsed Pokémon CSV on repository construction
- reuse cached dataset for all repository queries
- add tests verifying the CSV file is read only once

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68a05c2b2f84833090bf7bb53a8232e6