### PR TITLE
Centralize repository setup for Pokemon API

### DIFF
--- a/src/app/api/pokemon/[id]/route.ts
+++ b/src/app/api/pokemon/[id]/route.ts
@@ -1,20 +1,12 @@
 // src/app/api/pokemon/[id]/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import { Effect } from 'effect';
-import path from 'node:path';
 import {
   detail,
   PathInput,
   QueryInput,
 } from '@/application/pokemon/detail';
-import { PokemonRepositoryCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
-
-const DATA_PATH = path.resolve(
-  process.cwd(),
-  process.env.NODE_ENV === 'test'
-    ? 'data/pokemon_fixture_30.csv'
-    : 'data/pokemonCsv.csv'
-);
+import { getPokemonRepository } from '@/infrastructure/config';
 
 function getPathInput(params: { id: string }): PathInput {
   return { id: params.id };
@@ -26,7 +18,7 @@ function getQueryInput(req: NextRequest): QueryInput {
 }
 
 export async function GET(req: NextRequest, ctx: { params: { id: string } }) {
-  const repo = new PokemonRepositoryCsv(DATA_PATH);
+  const repo = getPokemonRepository();
   const result = await Effect.runPromise(
     detail(repo, { path: getPathInput(ctx.params), query: getQueryInput(req) })
   );

--- a/src/app/api/pokemon/route.ts
+++ b/src/app/api/pokemon/route.ts
@@ -1,15 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Effect } from 'effect';
-import path from 'node:path';
 import { list, QueryInput } from '@/application/pokemon/list';
-import { PokemonRepositoryCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
-
-const DATA_PATH = path.resolve(
-  process.cwd(),
-  process.env.NODE_ENV === 'test'
-    ? 'data/pokemon_fixture_30.csv'
-    : 'data/pokemonCsv.csv'
-);
+import { getPokemonRepository } from '@/infrastructure/config';
 
 // 把 URLSearchParams → QueryInput
 function getQueryInput(req: NextRequest): QueryInput {
@@ -19,7 +11,7 @@ function getQueryInput(req: NextRequest): QueryInput {
 
 // API route
 export async function GET(req: NextRequest) {
-  const repo = new PokemonRepositoryCsv(DATA_PATH);
+  const repo = getPokemonRepository();
   const result = await Effect.runPromise(list(repo, getQueryInput(req)));
   if (result._tag === 'Left') {
     return NextResponse.json(

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -1,0 +1,28 @@
+import path from 'node:path';
+import type { PokemonRepository } from '@/domain/repositories/PokemonRepository';
+import { PokemonRepositoryCsv } from '@/infrastructure/repositories/PokemonRepositoryCsv';
+
+function resolveDataPath(): string {
+  const envPath = process.env.POKEMON_DATA_PATH;
+  if (envPath) return path.resolve(process.cwd(), envPath);
+  return path.resolve(
+    process.cwd(),
+    process.env.NODE_ENV === 'test'
+      ? 'data/pokemon_fixture_30.csv'
+      : 'data/pokemonCsv.csv'
+  );
+}
+
+export function createPokemonRepository(): PokemonRepository {
+  return new PokemonRepositoryCsv(resolveDataPath());
+}
+
+let repository: PokemonRepository = createPokemonRepository();
+
+export function getPokemonRepository(): PokemonRepository {
+  return repository;
+}
+
+export function setPokemonRepository(repo: PokemonRepository): void {
+  repository = repo;
+}

--- a/tests/integration/api-route-config.test.ts
+++ b/tests/integration/api-route-config.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { Effect } from 'effect';
+import { TYPES, type TypeName, type Multiplier } from '@/domain/types';
+import type { Pokemon } from '@/domain/pokemon';
+import type { PokemonRepository } from '@/domain/repositories/PokemonRepository';
+import { setPokemonRepository, createPokemonRepository } from '@/infrastructure/config';
+import { GET } from '@/app/api/pokemon/route';
+
+class MockRepo implements PokemonRepository {
+  constructor(private readonly data: Pokemon[]) {}
+  getAll() {
+    return Effect.succeed(this.data);
+  }
+  getById(id: number) {
+    const p = this.data.find((x) => x.id === id);
+    return p ? Effect.succeed(p) : Effect.fail(new Error('not found'));
+  }
+  getByIdWithSimilar(id: number, k: number) {
+    const p = this.data.find((x) => x.id === id);
+    if (!p) return Effect.fail(new Error('not found'));
+    return Effect.succeed({ pokemon: p, similar: [] });
+  }
+}
+
+function dummyPokemon(id: number): Pokemon {
+  const against = Object.fromEntries(
+    TYPES.map((t) => [t, 1])
+  ) as Record<TypeName, Multiplier>;
+  return {
+    id,
+    name: `P${id}`,
+    type1: 'Normal',
+    type2: null,
+    abilities: [],
+    generation: 1,
+    legendary: false,
+    against,
+    hp: 1,
+    attack: 1,
+    defense: 1,
+    sp_atk: 1,
+    sp_def: 1,
+    speed: 1,
+    bst: 6,
+  };
+}
+
+describe('API route uses configured repository', () => {
+  afterEach(() => {
+    setPokemonRepository(createPokemonRepository());
+  });
+
+  it('returns data from mock repository', async () => {
+    setPokemonRepository(new MockRepo([dummyPokemon(1234)]));
+    const req = new NextRequest('http://test.local/api/pokemon');
+    const res = await GET(req);
+    const json: any = await res.json();
+    expect(json.data[0].id).toBe(1234);
+  });
+});


### PR DESCRIPTION
## Summary
- add `config.ts` to parse env vars and provide a configurable `PokemonRepository`
- update Pokemon API routes to retrieve the repository from this config module
- add integration test showing API route usage with a mock repository

## Testing
- `yarn test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68a07476258083308e09d8096f99d360