### PR TITLE
feat: add shared boolean helpers

### DIFF
--- a/src/application/pokemon/list.ts
+++ b/src/application/pokemon/list.ts
@@ -2,6 +2,7 @@ import { Effect, Schema as S } from 'effect';
 import type { PokemonRepository } from '@/domain/repositories/PokemonRepository';
 import type { Pokemon } from '@/domain/pokemon';
 import { invalidInput } from '../errors';
+import { toBoolLike } from '@/domain/bool';
 
 export const QuerySchema = S.Struct({
   q: S.optional(S.String),
@@ -13,14 +14,6 @@ export const QuerySchema = S.Struct({
 
 export type Query = S.Schema.Type<typeof QuerySchema>;
 export type QueryInput = S.Schema.Encoded<typeof QuerySchema>;
-
-function toBoolLike(raw?: string | null): boolean | undefined {
-  if (raw == null) return undefined;
-  const v = raw.trim().toLowerCase();
-  if (['true', '1', 'yes', 'y'].includes(v)) return true;
-  if (['false', '0', 'no', 'n'].includes(v)) return false;
-  return undefined;
-}
 
 /** 允許排序的欄位（白名單） */
 const ALLOWED_SORT_KEYS = new Set<keyof Pokemon>([

--- a/src/domain/bool.ts
+++ b/src/domain/bool.ts
@@ -1,0 +1,11 @@
+export function toBoolLike(raw?: string | number | boolean | null): boolean | undefined {
+  if (raw == null) return undefined;
+  const v = String(raw).trim().toLowerCase();
+  if (['true', '1', '1.0', 'yes', 'y'].includes(v)) return true;
+  if (['false', '0', '0.0', 'no', 'n'].includes(v)) return false;
+  return undefined;
+}
+
+export function toBool(raw?: string | number | boolean | null): boolean | undefined {
+  return toBoolLike(raw);
+}

--- a/src/infrastructure/csv/pokemonCsv.ts
+++ b/src/infrastructure/csv/pokemonCsv.ts
@@ -9,6 +9,7 @@ import {
   type Pokemon,
 } from '@/domain/pokemon';
 import { TYPES, type TypeName, type Multiplier } from '@/domain/types';
+import { toBool } from '@/domain/bool';
 
 const NumStr = S.NumberFromString;
 
@@ -75,15 +76,6 @@ export const parsePokemonCsv = (
       Effect.mapError((e) => new DataLoadError(String(e)))
     )
   );
-
-// —— 小工具：布林轉換 ——
-
-function toBool(raw?: string | null): boolean | undefined {
-  if (raw == null) return undefined;
-  const s = String(raw).trim().toLowerCase();
-  if (s === '') return undefined;
-  return s === '1.0';
-}
 
 // 方便安全索引 "Against XXX" 欄位
 type AgainstKey = `Against ${TypeName}`;

--- a/tests/domain/bool.test.ts
+++ b/tests/domain/bool.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { toBool, toBoolLike } from '@/domain/bool';
+
+describe('toBool & toBoolLike', () => {
+  const truthy = ['true', '1', '1.0', 'yes', 'y'];
+  const falsy = ['false', '0', '0.0', 'no', 'n'];
+
+  it('parses truthy values', () => {
+    for (const v of truthy) {
+      expect(toBool(v)).toBe(true);
+      expect(toBoolLike(v)).toBe(true);
+    }
+  });
+
+  it('parses falsy values', () => {
+    for (const v of falsy) {
+      expect(toBool(v)).toBe(false);
+      expect(toBoolLike(v)).toBe(false);
+    }
+  });
+
+  it('returns undefined for others', () => {
+    expect(toBool('foo')).toBeUndefined();
+    expect(toBoolLike('foo')).toBeUndefined();
+    expect(toBool()).toBeUndefined();
+    expect(toBoolLike()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add `toBool`/`toBoolLike` utilities for loose boolean conversion
- refactor Pokemon CSV mapper and listing query to reuse shared boolean helpers
- add unit tests covering diverse boolean inputs

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a077ecc61c8330950dde1c38ff95fc